### PR TITLE
feat: Add no audio feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ Generates short `.mp4` backdrop videos for Jellyfin or Emby libraries using FFmp
 
 ## 🎥 Features
 - Adjustable length, resolution, and compression
+- **Audio control**: Generate clips with or without audio (default: with audio)
+- **Expert mode**: Add custom FFmpeg parameters for advanced users
 - Avoids upscaling small sources
 - Safe random clip offset (not from start or end)
 - Automatically skips already processed files unless `--force` is used
 - Optional daemon mode for periodic rescanning
+- Failed attempt tracking with placeholder files
 
 ## 🚀 Usage
 
@@ -31,12 +34,54 @@ docker run --rm \
   --timeout 30
 ```
 
-### Example Flags
-- `--length`: Clip duration in seconds (default: 5)
-- `--resolution`: 720 or 1080 (default: 720)
-- `--crf`: Compression factor (lower is better quality; default: 28)
-- `--force`: Regenerate even if backdrop exists
-- `--timeout`: Timeout per FFmpeg call in seconds
+### Generate silent clips
+```bash
+docker run --rm \
+  -v /path/to/Movies:/movies \
+  -v /path/to/TV:/tv \
+  -e NO_AUDIO=true \
+  backdrop-generator
+```
+
+### Expert mode with custom FFmpeg parameters
+```bash
+docker run --rm \
+  -v /path/to/Movies:/movies \
+  -v /path/to/TV:/tv \
+  -e FFMPEG_EXTRA="-movflags +faststart -pix_fmt yuv420p" \
+  backdrop-generator
+```
+
+### Example Flags & Environment Variables
+- `--length` / `LENGTH`: Clip duration in seconds (default: 5)
+- `--resolution` / `RESOLUTION`: 720 or 1080 (default: 720)
+- `--crf` / `CRF`: Compression factor (lower is better quality; default: 28)
+- `--force` / `FORCE`: Regenerate even if backdrop exists (default: false)
+- `--timeout` / `TIMEOUT`: Timeout per FFmpeg call in seconds (default: 300)
+- `--no-audio` / `NO_AUDIO`: Generate clips without audio (default: false)
+- `--ffmpeg-extra` / `FFMPEG_EXTRA`: Custom FFmpeg parameters for expert users
+
+## 🔧 Advanced Configuration
+
+### Audio Options
+By default, clips include audio encoded with AAC. To generate silent clips:
+- Set `NO_AUDIO=true` environment variable, or
+- Use `--no-audio` flag when running directly
+
+### Expert Mode
+Add custom FFmpeg parameters using the `FFMPEG_EXTRA` environment variable:
+```bash
+# Example: Add fast start flag and specific pixel format
+FFMPEG_EXTRA="-movflags +faststart -pix_fmt yuv420p"
+
+# Example: Tune for film content with high profile
+FFMPEG_EXTRA="-tune film -profile:v high"
+
+# Example: Custom bitrate control
+FFMPEG_EXTRA="-maxrate 2M -bufsize 4M"
+```
+
+**Note**: Custom parameters are added to the FFmpeg command line. Use quotes for parameters with spaces.
 
 ## 🐳 Dockerfile Based
 This script uses FFmpeg inside a lightweight Python 3 image with minimal dependencies.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,8 @@ echo "  --timeout $TIMEOUT"
 echo "  --interval $INTERVAL"
 echo "  FORCE=$FORCE"
 echo "  DAEMON=$DAEMON"
+echo "  NO_AUDIO=$NO_AUDIO"
+echo "  FFMPEG_EXTRA=$FFMPEG_EXTRA"
 
 # Build args
 args=(
@@ -24,5 +26,9 @@ args=(
 # Conditionally add flags
 [ "$FORCE" = "true" ] && args+=(--force)
 [ "$DAEMON" = "true" ] && args+=(--daemon)
+[ "$NO_AUDIO" = "true" ] && args+=(--no-audio)
+
+# Add custom FFmpeg parameters if provided
+[ -n "$FFMPEG_EXTRA" ] && args+=(--ffmpeg-extra "$FFMPEG_EXTRA")
 
 exec python media_theme_processor.py "${args[@]}"

--- a/templates/backdrop-generator.xml
+++ b/templates/backdrop-generator.xml
@@ -9,7 +9,7 @@
   <Privileged>false</Privileged>
   <Support>https://forums.unraid.net/topic/190942-support-backdrop-generator-embyjellyfin-backdrop-video-generator/</Support>
   <Project>https://github.com/vLX42/backdrop-generator</Project>
-  <Overview>Generates .mp4 backdrop clips from your Jellyfin/Emby movie and TV libraries using FFmpeg. Fully configurable via Unraid UI.</Overview>
+  <Overview>Generates .mp4 backdrop clips from your Jellyfin/Emby movie and TV libraries using FFmpeg. Supports audio control and expert mode for custom FFmpeg parameters. Fully configurable via Unraid UI.</Overview>
   <Category>MediaApp:Video</Category>
   <WebUI/>
   <TemplateURL>https://raw.githubusercontent.com/vLX42/backdrop-generator/refs/heads/main/templates/backdrop-generator.xml</TemplateURL>
@@ -29,5 +29,7 @@
   <Config Name="Interval" Target="INTERVAL" Default="21600" Mode="rw" Description="Time between scans in seconds (default: 6 hours)." Type="Variable" Display="always" Required="false" Mask="false">21600</Config>
   <Config Name="Force Overwrite" Target="FORCE" Default="false" Mode="rw" Description="Force re-generation even if backdrop already exists." Type="Variable" Display="always" Required="false" Mask="false">false</Config>
   <Config Name="Daemon Mode" Target="DAEMON" Default="true" Mode="rw" Description="Enable daemon mode (runs continuously)." Type="Variable" Display="always" Required="false" Mask="false">true</Config>
+  <Config Name="No Audio" Target="NO_AUDIO" Default="false" Mode="rw" Description="Generate clips without audio (default: false = include audio)." Type="Variable" Display="always" Required="false" Mask="false">false</Config>
+  <Config Name="Expert Mode - Custom FFmpeg Parameters" Target="FFMPEG_EXTRA" Default="" Mode="rw" Description="Advanced: Additional FFmpeg parameters (e.g., '-movflags +faststart -pix_fmt yuv420p'). Leave empty for default behavior." Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
   <TailscaleStateDir/>
 </Container>


### PR DESCRIPTION
# Add Audio Control and Expert Mode Features

## 🎯 Overview
This PR adds two highly requested features to enhance flexibility and control over backdrop generation:
- **Audio Control**: Option to generate clips with or without audio
- **Expert Mode**: Ability to add custom FFmpeg parameters for advanced users

## ✨ New Features

### 1. Audio Control (`--no-audio`)
- **Default behavior**: Clips include audio (AAC encoding) - no breaking changes
- **New option**: `--no-audio` flag to generate silent clips
- **Use case**: Reduces file size and processing time when audio isn't needed for backdrops

### 2. Expert Mode (`--ffmpeg-extra`)
- **Custom FFmpeg parameters**: Add any additional FFmpeg arguments
- **Safe parsing**: Uses `shlex.split()` to handle quoted parameters properly
- **Flexible placement**: Custom parameters are intelligently inserted into the FFmpeg command
- **Error handling**: Graceful fallback if custom parameters can't be parsed

## 🔧 Implementation Details

### Python Script Changes
- Added `include_audio` and `ffmpeg_extra` parameters to `MediaBackdropProcessor`
- Enhanced `_extract_clip()` method to handle audio options and custom parameters
- Improved logging to show audio status and custom parameters being used
- Maintained backward compatibility - all existing functionality unchanged

### Docker/Unraid Integration
- **Launch script**: Added support for `NO_AUDIO` and `FFMPEG_EXTRA` environment variables
- **Unraid template**: Added two new configuration options with appropriate UI placement
- **Documentation**: Updated README with usage examples and advanced configuration guide

## 📋 Usage Examples

```bash
# Generate silent clips
python media_backdrop_processor.py --movies /movies --tv /tv --no-audio

# Expert mode with custom FFmpeg parameters
python media_backdrop_processor.py --movies /movies --tv /tv --ffmpeg-extra "-movflags +faststart -pix_fmt yuv420p"

# Docker with environment variables
docker run -e NO_AUDIO=true -e FFMPEG_EXTRA="-tune film" backdrop-generator
```

## 🧪 Testing
- [x] Verified backward compatibility (existing functionality unchanged)
- [x] Tested audio inclusion/exclusion
- [x] Tested custom FFmpeg parameter parsing and injection
- [x] Validated Docker environment variable handling
- [x] Confirmed Unraid template integration

## 📚 Documentation Updates
- Updated README.md with new features and examples
- Enhanced inline code documentation
- Added Unraid template configuration options
- Included advanced configuration section

## 🔄 Backward Compatibility
- ✅ **Fully backward compatible**
- ✅ Default behavior unchanged (audio included)
- ✅ All existing CLI arguments work identically
- ✅ No breaking changes to Docker or Unraid deployments

---

**Closes**: #[issue_number] (if applicable)  
**Type**: Feature Enhancement  
**Breaking Changes**: None